### PR TITLE
Added stopped or stopping instances to available instances count

### DIFF
--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -420,7 +420,8 @@ public abstract class EC2Cloud extends Cloud {
                     && isEc2ProvisionedJenkinsSlave(i.getTags(), jenkinsServerUrl)
                     && (template == null || template.getAmi().equals(i.getImageId()))) {
                     InstanceStateName stateName = InstanceStateName.fromValue(i.getState().getName());
-                    if (stateName != InstanceStateName.Terminated && stateName != InstanceStateName.ShuttingDown) {
+                    if (stateName != InstanceStateName.Terminated && stateName != InstanceStateName.ShuttingDown
+                            && stateName != InstanceStateName.Stopped && stateName != InstanceStateName.Stopping) {
                         LOGGER.log(Level.FINE, "Existing instance found: " + i.getInstanceId() + " AMI: " + i.getImageId()
                         + (template != null ? (" Template: " + description) : "") + " Jenkins Server: " + jenkinsServerUrl);
                         n++;


### PR DESCRIPTION
countCurrentEC2Slaves was not taking stopped or stopping slaves into account, causing a leak in the estimated number of required new slaves. 