### PR TITLE
Dt 607 check spot instance stop parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target
 build/
 
 \.gradle/
+
+*.hpi

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1260,21 +1260,17 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         /*
          * Validate the Spot Max Bid Price to ensure that it is a floating point number >= .001
          */
-        public FormValidation doCheckSpotMaxBidPrice(@QueryParameter String spotMaxBidPrice) {
-            if (SpotConfiguration.normalizeBid(spotMaxBidPrice) != null) {
-                return FormValidation.ok();
+        public FormValidation doCheckSpotMaxBidPrice(@QueryParameter String spotMaxBidPrice, @QueryParameter(required = true) Boolean useSpotInstancesNoBid) {
+            if (SpotConfiguration.normalizeBid(spotMaxBidPrice) == null && !useSpotInstancesNoBid) {
+                return FormValidation.error("Not a correct bid price");
             }
-            return FormValidation.error("Not a correct bid price");
+            return FormValidation.ok();
         }
 
-        public FormValidation doCheckStopOnTerminate(
-                @QueryParameter("stopOnTerminate") Boolean stopOnTerminate,
-                @QueryParameter("spotConfig") Boolean spotConfig,
-                @QueryParameter("useSpotInstancesNoBid") Boolean useSpotInstancesNoBid) {
+        public FormValidation doCheckStopOnTerminate(@QueryParameter Boolean stopOnTerminate, @QueryParameter Boolean spotConfig){
 
-            if (stopOnTerminate && ((spotConfig != null && spotConfig) || (useSpotInstancesNoBid != null && useSpotInstancesNoBid))) {
-                return FormValidation.error("Spot instances cannot be stopped. Choose one between 'Use Spot Instances without bid', " +
-                                            "'Use Spot Instances with bid' and 'Stop/Disconnect on Idle Timeout'.");
+            if (stopOnTerminate && ((spotConfig != null && spotConfig))) {
+                return FormValidation.error("Spot instances cannot be stopped. Choose one between 'Use spot instances' and 'Stop/Disconnect on Idle Timeout'.");
             }
             return FormValidation.ok();
         }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -129,7 +129,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean connectUsingPublicIp;
 
-    public final boolean useSpotInstancesNoBid;
+    public boolean useSpotInstancesNoBid;
 
     public boolean terminateRogues;
 
@@ -403,7 +403,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return iamInstanceProfile;
     }
 
-    public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
+    public boolean getSpotInstanceRequestBid() {
+        return !this.useSpotInstancesNoBid;
+    }
+
+    public void setSpotInstanceRequestBid(boolean value) {
+        this.useSpotInstancesNoBid = !value;
+    }
+
+    public enum ProvisionOptions {ALLOW_CREATE, FORCE_CREATE}
 
     /**
      * Provisions a new EC2 slave or starts a previously stopped on-demand instance.
@@ -530,6 +538,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             logProvisionInfo(logger, "Considering launching " + ami + " for template " + description);
 
             KeyPair keyPair = getKeyPair(ec2);
+
+            if (useSpotInstancesNoBid) {
+                InstanceMarketOptionsRequest instanceMarketOptionsRequest = new InstanceMarketOptionsRequest().withMarketType(
+                        MarketType.Spot);
+                riRequest.setInstanceMarketOptions(instanceMarketOptionsRequest);
+            }
 
             InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
 
@@ -1257,6 +1271,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 return FormValidation.ok();
             }
             return FormValidation.error("Not a correct bid price");
+        }
+
+        public FormValidation doCheckStopOnTerminate(
+                @QueryParameter("stopOnTerminate") Boolean stopOnTerminate, @QueryParameter("spotConfig") Boolean spotConfig) {
+            if (stopOnTerminate && (spotConfig != null && spotConfig)) {
+                return FormValidation.error("Cannot stop spot instances, choose one between 'Use Spot Instances' and 'Stop/Disconnect on Idle Timeout'.");
+            }
+            return FormValidation.ok();
         }
 
         // Retrieve the availability zones for the region

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1274,12 +1274,17 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         }
 
         public FormValidation doCheckStopOnTerminate(
-                @QueryParameter("stopOnTerminate") Boolean stopOnTerminate, @QueryParameter("spotConfig") Boolean spotConfig) {
-            if (stopOnTerminate && (spotConfig != null && spotConfig)) {
-                return FormValidation.error("Cannot stop spot instances, choose one between 'Use Spot Instances' and 'Stop/Disconnect on Idle Timeout'.");
+                @QueryParameter("stopOnTerminate") Boolean stopOnTerminate,
+                @QueryParameter("spotConfig") Boolean spotConfig,
+                @QueryParameter("useSpotInstancesNoBid") Boolean useSpotInstancesNoBid) {
+
+            if (stopOnTerminate && ((spotConfig != null && spotConfig) || (useSpotInstancesNoBid != null && useSpotInstancesNoBid))) {
+                return FormValidation.error("Spot instances cannot be stopped. Choose one between 'Use Spot Instances without bid', " +
+                                            "'Use Spot Instances with bid' and 'Stop/Disconnect on Idle Timeout'.");
             }
             return FormValidation.ok();
         }
+
 
         // Retrieve the availability zones for the region
         private ArrayList<String> getAvailabilityZones(AmazonEC2 ec2) {

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -1269,7 +1269,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         public FormValidation doCheckStopOnTerminate(@QueryParameter Boolean stopOnTerminate, @QueryParameter Boolean spotConfig){
 
-            if (stopOnTerminate && ((spotConfig != null && spotConfig))) {
+            if (stopOnTerminate && (spotConfig != null && spotConfig)) {
                 return FormValidation.error("Spot instances cannot be stopped. Choose one between 'Use spot instances' and 'Stop/Disconnect on Idle Timeout'.");
             }
             return FormValidation.ok();

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -539,12 +539,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             KeyPair keyPair = getKeyPair(ec2);
 
-            if (useSpotInstancesNoBid) {
-                InstanceMarketOptionsRequest instanceMarketOptionsRequest = new InstanceMarketOptionsRequest().withMarketType(
-                        MarketType.Spot);
-                riRequest.setInstanceMarketOptions(instanceMarketOptionsRequest);
-            }
-
             InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
 
             riRequest.setEbsOptimized(ebsOptimized);

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -61,7 +61,7 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Fallback to On-demand Instance}" field="spotInstanceFallbackToOnDemand">
+    <f:entry title="${%Fallback to On-Demand Instance}" field="spotInstanceFallbackToOnDemand">
         <f:checkbox />
     </f:entry>
   </f:optionalBlock>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -64,6 +64,16 @@ THE SOFTWARE.
     <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
       <f:textbox />
     </f:entry>
+
+  <f:optionalBlock name="spotConfig" title="${%Use Spot Instance}" checked="${instance.spotConfig != null}">
+    <f:optionalBlock name="spotInstanceRequestBid" title="${%Set Spot Instance Bid Price}" checked="${!instance.useSpotInstancesNoBid}">
+      <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice"
+       with="useInstanceProfileForCredentials,credentialsId,region,type,zone" />
+
+      <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
   </f:optionalBlock>
 
   <f:entry title="${%Security group names}" field="securityGroups">
@@ -112,7 +122,7 @@ THE SOFTWARE.
       <f:textbox/>
     </f:entry>
 
-    <f:entry title="${%Stop/Disconnect on Idle Timeout}" field="stopOnTerminate">
+    <f:entry title="${%Stop/Disconnect on Idle Timeout}" field="stopOnTerminate" with="spotConfig">
       <f:checkbox />
     </f:entry>
 

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -50,22 +50,21 @@ THE SOFTWARE.
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="${%Use Spot Instances without bid}" field="useSpotInstancesNoBid">
-    <f:checkbox />
-  </f:entry>
-
-  <f:optionalBlock name="spotConfig" title="Use Spot Instance with bid" checked="${instance.spotConfig != null}">
+  <f:optionalBlock name="spotConfig" title="Use Spot Instance" checked="${instance.spotConfig != null}">
     <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice"
      with="useInstanceProfileForCredentials,credentialsId,region,type,zone" />
+    <f:entry title="${%No Bid}" field="useSpotInstancesNoBid">
+        <f:checkbox />
+    </f:entry>
 
-    <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
+    <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice" with="useSpotInstancesNoBid">
       <f:textbox />
     </f:entry>
-  </f:optionalBlock>
 
-  <f:entry title="${%Fallback to on-demand Instance}" field="spotInstanceFallbackToOnDemand">
-    <f:checkbox />
-  </f:entry>
+    <f:entry title="${%Fallback to on-demand Instance}" field="spotInstanceFallbackToOnDemand">
+        <f:checkbox />
+    </f:entry>
+  </f:optionalBlock>
 
   <f:entry title="${%Security group names}" field="securityGroups">
     <f:textbox/>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -61,7 +61,7 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
 
-    <f:entry title="${%Fallback to on-demand Instance}" field="spotInstanceFallbackToOnDemand">
+    <f:entry title="${%Fallback to On-demand Instance}" field="spotInstanceFallbackToOnDemand">
         <f:checkbox />
     </f:entry>
   </f:optionalBlock>

--- a/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/SlaveTemplate/config.jelly
@@ -54,20 +54,18 @@ THE SOFTWARE.
     <f:checkbox />
   </f:entry>
 
+  <f:optionalBlock name="spotConfig" title="Use Spot Instance with bid" checked="${instance.spotConfig != null}">
+    <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice"
+     with="useInstanceProfileForCredentials,credentialsId,region,type,zone" />
+
+    <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
+      <f:textbox />
+    </f:entry>
+  </f:optionalBlock>
+
   <f:entry title="${%Fallback to on-demand Instance}" field="spotInstanceFallbackToOnDemand">
     <f:checkbox />
   </f:entry>
-
-  <f:optionalBlock name="spotConfig" title="${%Use Spot Instance}" checked="${instance.spotConfig != null}">
-    <f:optionalBlock name="spotInstanceRequestBid" title="${%Set Spot Instance Bid Price}" checked="${!instance.useSpotInstancesNoBid}">
-      <f:validateButton title="${%Check Current Spot Price}" progress="${%Checking...}" method="currentSpotPrice"
-       with="useInstanceProfileForCredentials,credentialsId,region,type,zone" />
-
-      <f:entry title="${%Spot Max Bid Price}" field="spotMaxBidPrice">
-        <f:textbox />
-      </f:entry>
-    </f:optionalBlock>
-  </f:optionalBlock>
 
   <f:entry title="${%Security group names}" field="securityGroups">
     <f:textbox/>


### PR DESCRIPTION
-"Use spot instances without bid" and "Use spot instances with Bid" are now together under "Use spot instances"
-Fallback option appears under the "use spot instances" 
-Validation changed for spot price, only gives error if "No bid" is not set
-Confirmed that "Stop on terminate" parameter gives error if "Use Spot Instances" is checked.